### PR TITLE
Added a setting for deletion behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dendron-tree",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dendron-tree",
-      "version": "1.1.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",

--- a/src/components/NoteComponent.svelte
+++ b/src/components/NoteComponent.svelte
@@ -35,7 +35,10 @@
   function deleteCurrentNote() {
     const plugin = getPlugin();
     if (!note.file) return;
-    plugin.app.vault.delete(note.file);
+    if (plugin.settings.deleteMethod === "moveToTrash")
+      plugin.app.vault.trash(note.file, true);
+    else if (plugin.settings.deleteMethod === "deletePermanently")
+      plugin.app.vault.delete(note.file);
   }
 
   function openLookup() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export interface DendronTreePluginSettings {
   autoReveal: boolean;
   customResolver: boolean;
   customGraph: boolean;
+  deleteMethod: string;
 }
 
 export const DEFAULT_SETTINGS: DendronTreePluginSettings = {
@@ -26,6 +27,7 @@ export const DEFAULT_SETTINGS: DendronTreePluginSettings = {
   autoReveal: true,
   customResolver: false,
   customGraph: false,
+  deleteMethod: "moveToTrash",
 };
 
 export class DendronTreeSettingTab extends PluginSettingTab {
@@ -42,6 +44,20 @@ export class DendronTreeSettingTab extends PluginSettingTab {
     containerEl.empty();
 
     containerEl.createEl("h2", { text: "Dendron Tree Settting" });
+    
+    new Setting(containerEl)
+    .setName("Deletion Method")
+    .setDesc(
+      "What happens when you delete a file"
+    )
+    .addDropdown(dropdown => dropdown
+      .addOption('moveToTrash', 'Move to Trash')
+      .addOption('deletePermanently', 'Delete Permanently')
+      .setValue(this.plugin.settings.deleteMethod || 'moveToTrash')
+      .onChange(async (value) => {
+        this.plugin.settings.deleteMethod = value;
+        await this.plugin.saveSettings();
+      }));
 
     new Setting(containerEl)
       .setName("Auto Generate Front Matter")


### PR DESCRIPTION
Added a user setting to control note deletion behavior.

- "Move to Trash" moves the note to system trash instead of permanently deleting it.
- "Delete Permanently" is the same behavior as currently implemented, completely deleting the file.
- Default is "Move to Trash"

Closes #16 